### PR TITLE
[FEATURE] Phar building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 vendor
 .env
+*.phar

--- a/Readme.md
+++ b/Readme.md
@@ -25,6 +25,20 @@ Some of the features of the Surf package:
 > Surf ist still work-in-progress. API and options are subject to
 > change.
 
+Building the phar
+-----------------
+
+```
+# Install box globally (remember to add ~/.composer/vendor/bin to $PATH)
+~$ curl -LSs http://box-project.org/installer.php | php
+
+# Build
+~$ box build
+
+#Test
+~$ php surf.phar
+```
+
 Installation
 ------------
 

--- a/box.json
+++ b/box.json
@@ -1,0 +1,31 @@
+{
+  "alias": "surf.phar",
+  "directories": [
+    "src/"
+  ],
+  "finder": [
+    {
+      "name": "*.php",
+      "exclude": [
+        ".gitignore",
+        ".md",
+        "phpunit",
+        "Tester",
+        "Tests",
+        "tests",
+        "yaml"
+      ],
+      "in": "vendor"
+    }
+  ],
+  "compactors": [
+    "Herrera\\Box\\Compactor\\Json",
+    "Herrera\\Box\\Compactor\\Php"
+  ],
+  "compression": "GZ",
+  "git-version": "package_version",
+  "main": "surf.php",
+  "output": "surf.phar",
+  "stub": true,
+  "chmod": "0755"
+}

--- a/surf.php
+++ b/surf.php
@@ -3,8 +3,6 @@
 
 require __DIR__.'/vendor/autoload.php';
 
-Dotenv::load(__DIR__);
-
 use TYPO3\Surf\Command\ListCommand;
 use TYPO3\Surf\Command\DeployCommand;
 use TYPO3\Surf\Command\DescribeCommand;


### PR DESCRIPTION
Brings the ability to package surf as PHP archive file (phar).
This is done with the help of the "box" project (https://github.com/box-project/box2)

Note: This disables the the Dotenv reading as we cannot guarantee there is a .env file
in `__DIR__` and relative paths in a phar are tricky.

# Building

```
# Install box globally (remember to add ~/.composer/vendor/bin to $PATH)
~$ curl -LSs http://box-project.org/installer.php | php

# Build
~$ box build

#Test
~$ php surf.phar
```